### PR TITLE
enable optional validation on custom binding source models

### DIFF
--- a/FluentValidation.AutoValidation.Mvc/src/Configuration/AutoValidationMvcConfiguration.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Configuration/AutoValidationMvcConfiguration.cs
@@ -36,6 +36,11 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Configuration
         public bool EnableQueryBindingSourceAutomaticValidation { get; set; } = true;
 
         /// <summary>
+        /// Enables asynchronous automatic validation for parameters bound from the <see cref="BindingSource.Custom"/> binding source.
+        /// </summary>
+        public bool EnableCustomBindingSourceAutomaticValidation { get; set; } = false;
+
+        /// <summary>
         /// Holds the overridden result factory. This property is meant for infrastructure and should not be used by application code.
         /// </summary>
         public Type? OverriddenResultFactory { get; private set; }

--- a/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
@@ -54,10 +54,12 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Filters
                         var parameterType = parameter.ParameterType;
                         var bindingSource = parameter.BindingInfo?.BindingSource;
 
-                        if (subject != null && parameterType.IsCustomType() &&
-                            ((autoValidationMvcConfiguration.EnableBodyBindingSourceAutomaticValidation && bindingSource == BindingSource.Body) ||
+                        if (subject != null 
+                         && parameterType.IsCustomType() 
+                         && ((autoValidationMvcConfiguration.EnableBodyBindingSourceAutomaticValidation && bindingSource == BindingSource.Body) ||
                              (autoValidationMvcConfiguration.EnableFormBindingSourceAutomaticValidation && bindingSource == BindingSource.Form) ||
-                             (autoValidationMvcConfiguration.EnableQueryBindingSourceAutomaticValidation && bindingSource == BindingSource.Query)))
+                             (autoValidationMvcConfiguration.EnableQueryBindingSourceAutomaticValidation && bindingSource == BindingSource.Query) || 
+                             (autoValidationMvcConfiguration.EnableCustomBindingSourceAutomaticValidation && bindingSource == BindingSource.Custom)))
                         {
                             if (serviceProvider.GetValidator(parameterType) is IValidator validator)
                             {


### PR DESCRIPTION
Resolves #11 

I believe there's opportunity to add testing, as well as perhaps a more generic solution that might cover the *other* binding types?