### PR TITLE
Use the method parameter's runtime (instance) type to find the validator instead of its declared type

### DIFF
--- a/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
@@ -61,9 +61,9 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Filters
                         var hasAutoValidateAlwaysAttribute = parameterInfo?.HasCustomAttribute<AutoValidateAlwaysAttribute>() ?? false;
                         var hasAutoValidateNeverAttribute = parameterInfo?.HasCustomAttribute<AutoValidateNeverAttribute>() ?? false;
 
-                        if (subject != null && parameterType.IsCustomType() &&
+                        if (subject != null && parameterType != null && parameterType.IsCustomType() &&
                             !hasAutoValidateNeverAttribute && (hasAutoValidateAlwaysAttribute || HasValidBindingSource(bindingSource)) &&
-                            serviceProvider.GetValidator(parameterType!) is IValidator validator)
+                            serviceProvider.GetValidator(parameterType) is IValidator validator)
                         {
                             // ReSharper disable once SuspiciousTypeConversion.Global
                             var validatorInterceptor = validator as IValidatorInterceptor;

--- a/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
@@ -55,7 +55,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Filters
                     if (actionExecutingContext.ActionArguments.TryGetValue(parameter.Name, out var subject))
                     {
                         var parameterInfo = (parameter as ControllerParameterDescriptor)?.ParameterInfo;
-                        var parameterType = subject!.GetType();
+                        var parameterType = subject?.GetType();
                         var bindingSource = parameter.BindingInfo?.BindingSource;
 
                         var hasAutoValidateAlwaysAttribute = parameterInfo?.HasCustomAttribute<AutoValidateAlwaysAttribute>() ?? false;
@@ -63,7 +63,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Filters
 
                         if (subject != null && parameterType.IsCustomType() &&
                             !hasAutoValidateNeverAttribute && (hasAutoValidateAlwaysAttribute || HasValidBindingSource(bindingSource)) &&
-                            serviceProvider.GetValidator(parameterType) is IValidator validator)
+                            serviceProvider.GetValidator(parameterType!) is IValidator validator)
                         {
                             // ReSharper disable once SuspiciousTypeConversion.Global
                             var validatorInterceptor = validator as IValidatorInterceptor;

--- a/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
@@ -55,7 +55,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Filters
                     if (actionExecutingContext.ActionArguments.TryGetValue(parameter.Name, out var subject))
                     {
                         var parameterInfo = (parameter as ControllerParameterDescriptor)?.ParameterInfo;
-                        var parameterType = parameter.ParameterType;
+                        var parameterType = subject!.GetType();
                         var bindingSource = parameter.BindingInfo?.BindingSource;
 
                         var hasAutoValidateAlwaysAttribute = parameterInfo?.HasCustomAttribute<AutoValidateAlwaysAttribute>() ?? false;


### PR DESCRIPTION
Fixes #46