### PR TITLE
Convert to `netstandard2.0` sample

### DIFF
--- a/FluentValidation.AutoValidation.Mvc/FluentValidation.AutoValidation.Mvc.csproj
+++ b/FluentValidation.AutoValidation.Mvc/FluentValidation.AutoValidation.Mvc.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <RootNamespace>SharpGrip.FluentValidation.AutoValidation.Mvc</RootNamespace>
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <AssemblyName>SharpGrip.FluentValidation.AutoValidation.Mvc</AssemblyName>
         <PackageId>SharpGrip.FluentValidation.AutoValidation.Mvc</PackageId>
         <Title>SharpGrip FluentValidation AutoValidation MVC</Title>
@@ -25,7 +25,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FluentValidation.AutoValidation.Mvc/src/Validation/FluentValidationAutoValidationObjectModelValidator.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Validation/FluentValidationAutoValidationObjectModelValidator.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+#if !NET
+using Microsoft.AspNetCore.Mvc.Internal;
+#endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 

--- a/FluentValidation.AutoValidation.Mvc/src/Validation/FluentValidationAutoValidationValidationVisitor.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Validation/FluentValidationAutoValidationValidationVisitor.cs
@@ -1,4 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+#if !NET
+using Microsoft.AspNetCore.Mvc.Internal;
+#endif
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
@@ -25,7 +28,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Validation
             return disableBuiltInModelValidation || base.Validate(metadata, key, model, alwaysValidateAtTopLevel);
         }
 
-#if !NETCOREAPP3_1
+#if NET
         public override bool Validate(ModelMetadata? metadata, string? key, object? model, bool alwaysValidateAtTopLevel, object? container)
         {
             // If built in model validation is disabled return true for later validation in the action filter.


### PR DESCRIPTION
Sample PR with modifications needed to make `FluentValidation.AutoValidation.Mvc` work while targeting `netstandard2.0`.