### PR TITLE
Add AOT compatibility annotations and flags for FluentValidation

### DIFF
--- a/FluentValidation.AutoValidation.Endpoints/FluentValidation.AutoValidation.Endpoints.csproj
+++ b/FluentValidation.AutoValidation.Endpoints/FluentValidation.AutoValidation.Endpoints.csproj
@@ -11,6 +11,7 @@
         <Title>SharpGrip FluentValidation AutoValidation Endpoints</Title>
         <Description>SharpGrip FluentValidation AutoValidation Endpoints is an extension of the FluentValidation library enabling automatic asynchronous validation in minimal APIs (endpoints).</Description>
         <PackageTags>sharpgrip;validation;fluent-validation;endpoints;minimal-api</PackageTags>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/FluentValidation.AutoValidation.Endpoints/src/Configuration/AutoValidationEndpointsConfiguration.cs
+++ b/FluentValidation.AutoValidation.Endpoints/src/Configuration/AutoValidationEndpointsConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http.HttpResults;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Results;
 
@@ -9,6 +10,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Configuration
         /// <summary>
         /// Holds the overridden result factory. This property is meant for infrastructure and should not be used by application code.
         /// </summary>
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? OverriddenResultFactory { get; private set; }
 
         /// <summary>
@@ -17,7 +19,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Configuration
         /// </summary>
         /// <see cref="FluentValidationAutoValidationDefaultResultFactory"/>
         /// <typeparam name="TResultFactory">The custom result factory implementing <see cref="IFluentValidationAutoValidationResultFactory"/>.</typeparam>
-        public void OverrideDefaultResultFactoryWith<TResultFactory>() where TResultFactory : IFluentValidationAutoValidationResultFactory
+        public void OverrideDefaultResultFactoryWith<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TResultFactory>() where TResultFactory : IFluentValidationAutoValidationResultFactory
         {
             OverriddenResultFactory = typeof(TResultFactory);
         }

--- a/FluentValidation.AutoValidation.Endpoints/src/Extensions/EndpointRouteExtensions.cs
+++ b/FluentValidation.AutoValidation.Endpoints/src/Extensions/EndpointRouteExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Filters;
@@ -12,6 +13,11 @@ namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions
         /// </summary>
         /// <param name="routeHandlerBuilder">The route handler builder.</param>
         /// <returns>The route handler builder.</returns>
+        /// <remarks>
+        /// For AOT validation to work, the validator itself must be marked [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(YourValidator!)] to ensure it's preserved.<br/>
+        /// Otherwise, it will not be found at runtime and the validation will NOT happen.<br/>
+        /// </remarks>
+        [RequiresUnreferencedCode("Requires unreferenced code to locate and access IValidator<> types at runtime, it only works for types that are known (and preserved) at compile time. See remarks for more details.")]
         public static RouteHandlerBuilder AddFluentValidationAutoValidation(this RouteHandlerBuilder routeHandlerBuilder)
         {
             routeHandlerBuilder.AddEndpointFilter<FluentValidationAutoValidationEndpointFilter>();
@@ -24,6 +30,11 @@ namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Extensions
         /// </summary>
         /// <param name="routeGroupBuilder">The route group builder.</param>
         /// <returns>The route group builder.</returns>
+        /// <remarks>
+        /// For AOT validation to work, the validator itself must be marked as DynamicDependency to ensure it's preserved:<code>[DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(YourValidator!)]</code><br/>
+        /// <b>Otherwise, it will not be found at runtime and the validation will NOT happen.</b><br/>
+        /// </remarks>
+        [RequiresUnreferencedCode("Requires unreferenced code to locate and access IValidator<> types at runtime, it only works for types that are known (and preserved) at compile time. See remarks for more details.")]
         public static RouteGroupBuilder AddFluentValidationAutoValidation(this RouteGroupBuilder routeGroupBuilder)
         {
             routeGroupBuilder.AddEndpointFilter<FluentValidationAutoValidationEndpointFilter>();

--- a/FluentValidation.AutoValidation.Shared/FluentValidation.AutoValidation.Shared.csproj
+++ b/FluentValidation.AutoValidation.Shared/FluentValidation.AutoValidation.Shared.csproj
@@ -11,6 +11,7 @@
         <Title>SharpGrip FluentValidation AutoValidation Shared</Title>
         <Description>SharpGrip FluentValidation AutoValidation is an extension of the FluentValidation library enabling automatic asynchronous validation in MVC controllers and minimal APIs (endpoints).</Description>
         <PackageTags>sharpgrip;validation;fluent-validation;mvc;endpoints;minimal-api</PackageTags>
+        <IsAotCompatible>true</IsAotCompatible>
     </PropertyGroup>
 
     <ItemGroup>

--- a/FluentValidation.AutoValidation.Shared/src/Extensions/ServiceProviderExtensions.cs
+++ b/FluentValidation.AutoValidation.Shared/src/Extensions/ServiceProviderExtensions.cs
@@ -1,10 +1,17 @@
 ﻿using System;
 using FluentValidation;
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace SharpGrip.FluentValidation.AutoValidation.Shared.Extensions
 {
     public static class ServiceProviderExtensions
     {
+#if NET7_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(IValidator<>))]
+        [UnconditionalSuppressMessage("Aot", "IL3050", Justification = "Validators should be preserved by the compiler if the user has marked them with [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(YourValidator!)] or similar.")]
+#endif
         public static object? GetValidator(this IServiceProvider serviceProvider, Type type)
         {
             return serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(type));


### PR DESCRIPTION
- Mark relevant methods and properties with `[RequiresUnreferencedCode]` or `[DynamicDependency]` to support Ahead-Of-Time (AOT) compilation.
- Add `<IsAotCompatible>` property to project files for compatibility metadata.
- Suppress warnings where validators are expected to be preserved by user annotations.


<img width="1151" height="478" alt="image" src="https://github.com/user-attachments/assets/eef817e0-f9a0-48a2-a4ba-07880693bef9" />
