### PR TITLE
Implement base type and interface validation fallback for Minimal APIs

### DIFF
--- a/FluentValidation.AutoValidation.Endpoints/src/Configuration/AutoValidationEndpointsConfiguration.cs
+++ b/FluentValidation.AutoValidation.Endpoints/src/Configuration/AutoValidationEndpointsConfiguration.cs
@@ -2,24 +2,41 @@
 using Microsoft.AspNetCore.Http.HttpResults;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Results;
 
-namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Configuration
-{
-    public class AutoValidationEndpointsConfiguration
-    {
-        /// <summary>
-        /// Holds the overridden result factory. This property is meant for infrastructure and should not be used by application code.
-        /// </summary>
-        public Type? OverriddenResultFactory { get; private set; }
+namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Configuration;
 
-        /// <summary>
-        /// Overrides the default result factory with a custom result factory. Custom result factories are required to implement <see cref="IFluentValidationAutoValidationResultFactory"/>.
-        /// The default result factory returns the validation errors wrapped in a <see cref="ValidationProblem"/> object. 
-        /// </summary>
-        /// <see cref="FluentValidationAutoValidationDefaultResultFactory"/>
-        /// <typeparam name="TResultFactory">The custom result factory implementing <see cref="IFluentValidationAutoValidationResultFactory"/>.</typeparam>
-        public void OverrideDefaultResultFactoryWith<TResultFactory>() where TResultFactory : IFluentValidationAutoValidationResultFactory
-        {
-            OverriddenResultFactory = typeof(TResultFactory);
-        }
+public class AutoValidationEndpointsConfiguration
+{
+    /// <summary>
+    /// Gets a value indicating whether the validation process should look for validators
+    /// registered for interfaces or base types when a validator for the concrete type is not found.
+    /// </summary>
+    public bool UseBaseTypeValidations { get; private set; }
+
+    /// <summary>
+    /// Holds the overridden result factory. This property is meant for infrastructure and should not be used by application code.
+    /// </summary>
+    public Type? OverriddenResultFactory { get; private set; }
+
+    /// <summary>
+    /// Overrides the default result factory with a custom result factory. Custom result factories are required to implement <see cref="IFluentValidationAutoValidationResultFactory" />.
+    /// The default result factory returns the validation errors wrapped in a <see cref="ValidationProblem" /> object.
+    /// </summary>
+    /// <see cref="FluentValidationAutoValidationDefaultResultFactory" />
+    /// <typeparam name="TResultFactory">The custom result factory implementing <see cref="IFluentValidationAutoValidationResultFactory" />.</typeparam>
+    public AutoValidationEndpointsConfiguration OverrideDefaultResultFactoryWith<TResultFactory>() where TResultFactory : IFluentValidationAutoValidationResultFactory
+    {
+        OverriddenResultFactory = typeof(TResultFactory);
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the fallback mechanism to search for validators in the type hierarchy (interfaces and base classes)
+    /// if no specific validator is registered for the primary parameter type.
+    /// </summary>
+    /// <returns>The current <see cref="AutoValidationEndpointsConfiguration" /> instance for fluent chaining.</returns>
+    public AutoValidationEndpointsConfiguration WithBaseTypeValidations()
+    {
+        UseBaseTypeValidations = true;
+        return this;
     }
 }

--- a/FluentValidation.AutoValidation.Endpoints/src/Filters/FluentValidationAutoValidationEndpointFilter.cs
+++ b/FluentValidation.AutoValidation.Endpoints/src/Filters/FluentValidationAutoValidationEndpointFilter.cs
@@ -1,15 +1,19 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentValidation;
+using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SharpGrip.FluentValidation.AutoValidation.Endpoints.Configuration;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Interceptors;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Results;
 using SharpGrip.FluentValidation.AutoValidation.Shared.Extensions;
 
 namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Filters
 {
-    public class FluentValidationAutoValidationEndpointFilter(ILogger<FluentValidationAutoValidationEndpointFilter> logger) : IEndpointFilter
+    public class FluentValidationAutoValidationEndpointFilter(ILogger<FluentValidationAutoValidationEndpointFilter> logger, IOptions<AutoValidationEndpointsConfiguration> options) : IEndpointFilter
     {
         public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext endpointFilterInvocationContext, EndpointFilterDelegate next)
         {
@@ -17,66 +21,80 @@ namespace SharpGrip.FluentValidation.AutoValidation.Endpoints.Filters
 
             foreach (var argument in endpointFilterInvocationContext.Arguments)
             {
-                if (argument != null && argument.GetType().IsCustomType() && serviceProvider.GetValidator(argument.GetType()) is IValidator validator)
+                if (argument == null) continue;
+                
+                if (!argument.GetType().IsCustomType() || serviceProvider.GetValidator(argument.GetType(), options.Value.UseBaseTypeValidations) is not IValidator validator)
                 {
-                    logger.LogDebug("Starting validation for argument of type '{Type}'.", argument.GetType().Name);
-
-                    var validatorInterceptor = validator as IValidatorInterceptor;
-                    var globalValidationInterceptor = serviceProvider.GetService<IGlobalValidationInterceptor>();
-
-                    IValidationContext validationContext = new ValidationContext<object>(argument);
-
-                    if (validatorInterceptor != null)
-                    {
-                        logger.LogDebug("Invoking validator interceptor BeforeValidation for argument '{Argument}'.", argument.GetType().Name);
-                        validationContext = await validatorInterceptor.BeforeValidation(endpointFilterInvocationContext, validationContext, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationContext;
-                    }
-
-                    if (globalValidationInterceptor != null)
-                    {
-                        logger.LogDebug("Invoking global validation interceptor BeforeValidation for argument '{Argument}'.", argument.GetType().Name);
-                        validationContext = await globalValidationInterceptor.BeforeValidation(endpointFilterInvocationContext, validationContext, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationContext;
-                    }
-
-                    var validationResult = await validator.ValidateAsync(validationContext, endpointFilterInvocationContext.HttpContext.RequestAborted);
-
-                    if (validatorInterceptor != null)
-                    {
-                        logger.LogDebug("Invoking validator interceptor AfterValidation for argument '{Argument}'.", argument.GetType().Name);
-                        validationResult = await validatorInterceptor.AfterValidation(endpointFilterInvocationContext, validationContext, validationResult, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationResult;
-                    }
-
-                    if (globalValidationInterceptor != null)
-                    {
-                        logger.LogDebug("Invoking global validation interceptor AfterValidation for argument '{Argument}'.", argument.GetType().Name);
-                        validationResult = await globalValidationInterceptor.AfterValidation(endpointFilterInvocationContext, validationContext, validationResult, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationResult;
-                    }
-
-                    if (!validationResult.IsValid)
-                    {
-                        logger.LogDebug("Validation result not valid for argument '{Argument}': {ErrorCount} validation error(s) found.", argument.GetType().Name, validationResult.Errors.Count);
-
-                        var fluentValidationAutoValidationResultFactory = serviceProvider.GetService<IFluentValidationAutoValidationResultFactory>();
-
-                        logger.LogDebug("Creating result for path '{Path}'.", endpointFilterInvocationContext.HttpContext.Request.Path);
-
-                        if (fluentValidationAutoValidationResultFactory != null)
-                        {
-                            logger.LogTrace("Creating result for path '{Path}' using a custom result factory.", endpointFilterInvocationContext.HttpContext.Request.Path);
-
-                            return fluentValidationAutoValidationResultFactory.CreateResult(endpointFilterInvocationContext, validationResult);
-                        }
-
-                        logger.LogTrace("Creating result for path '{Path}' using the default result factory.", endpointFilterInvocationContext.HttpContext.Request.Path);
-
-                        return new FluentValidationAutoValidationDefaultResultFactory().CreateResult(endpointFilterInvocationContext, validationResult);
-                    }
-
-                    logger.LogDebug("Validation result valid for argument '{Argument}'.", argument.GetType().Name);
+                    logger.LogDebug("Skipping argument of type '{Type}'. It's not a custom type, or no validator was found for this type.", argument.GetType().Name);
+                    continue;
                 }
+                
+                logger.LogDebug("Starting validation for argument of type '{Type}'.", argument.GetType().Name);
+
+                var validationResult = await ExecuteValidation(endpointFilterInvocationContext, validator, serviceProvider, argument);
+
+                if (!validationResult.IsValid) return CreateAInvalidResult(endpointFilterInvocationContext, argument, validationResult, serviceProvider);
+
+                logger.LogDebug("Validation result valid for argument '{Argument}'.", argument.GetType().Name);
             }
 
             return await next(endpointFilterInvocationContext);
+        }
+
+        private object CreateAInvalidResult(EndpointFilterInvocationContext endpointFilterInvocationContext, object argument, ValidationResult validationResult, IServiceProvider serviceProvider)
+        {
+            logger.LogDebug("Validation result not valid for argument '{Argument}': {ErrorCount} validation error(s) found.", argument.GetType().Name, validationResult.Errors.Count);
+
+            var fluentValidationAutoValidationResultFactory = serviceProvider.GetService<IFluentValidationAutoValidationResultFactory>();
+
+            logger.LogDebug("Creating result for path '{Path}'.", endpointFilterInvocationContext.HttpContext.Request.Path);
+
+            if (fluentValidationAutoValidationResultFactory != null)
+            {
+                logger.LogTrace("Creating result for path '{Path}' using a custom result factory.", endpointFilterInvocationContext.HttpContext.Request.Path);
+
+                return fluentValidationAutoValidationResultFactory.CreateResult(endpointFilterInvocationContext, validationResult);
+            }
+
+            logger.LogTrace("Creating result for path '{Path}' using the default result factory.", endpointFilterInvocationContext.HttpContext.Request.Path);
+
+            return new FluentValidationAutoValidationDefaultResultFactory().CreateResult(endpointFilterInvocationContext, validationResult);
+        }
+
+        private async ValueTask<ValidationResult> ExecuteValidation(EndpointFilterInvocationContext endpointFilterInvocationContext, IValidator validator, IServiceProvider serviceProvider, object argument)
+        {
+            var validatorInterceptor = validator as IValidatorInterceptor;
+            var globalValidationInterceptor = serviceProvider.GetService<IGlobalValidationInterceptor>();
+
+            IValidationContext validationContext = new ValidationContext<object>(argument);
+
+            if (validatorInterceptor != null)
+            {
+                logger.LogDebug("Invoking validator interceptor BeforeValidation for argument '{Argument}'.", argument.GetType().Name);
+                validationContext = await validatorInterceptor.BeforeValidation(endpointFilterInvocationContext, validationContext, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationContext;
+            }
+
+            if (globalValidationInterceptor != null)
+            {
+                logger.LogDebug("Invoking global validation interceptor BeforeValidation for argument '{Argument}'.", argument.GetType().Name);
+                validationContext = await globalValidationInterceptor.BeforeValidation(endpointFilterInvocationContext, validationContext, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationContext;
+            }
+
+            var validationResult = await validator.ValidateAsync(validationContext, endpointFilterInvocationContext.HttpContext.RequestAborted);
+
+            if (validatorInterceptor != null)
+            {
+                logger.LogDebug("Invoking validator interceptor AfterValidation for argument '{Argument}'.", argument.GetType().Name);
+                validationResult = await validatorInterceptor.AfterValidation(endpointFilterInvocationContext, validationContext, validationResult, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationResult;
+            }
+
+            if (globalValidationInterceptor != null)
+            {
+                logger.LogDebug("Invoking global validation interceptor AfterValidation for argument '{Argument}'.", argument.GetType().Name);
+                validationResult = await globalValidationInterceptor.AfterValidation(endpointFilterInvocationContext, validationContext, validationResult, endpointFilterInvocationContext.HttpContext.RequestAborted) ?? validationResult;
+            }
+
+            return validationResult;
         }
     }
 }

--- a/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
+++ b/FluentValidation.AutoValidation.Mvc/src/Filters/FluentValidationAutoValidationActionFilter.cs
@@ -61,7 +61,7 @@ namespace SharpGrip.FluentValidation.AutoValidation.Mvc.Filters
                         var hasAutoValidateAlwaysAttribute = parameterInfo?.HasCustomAttribute<AutoValidateAlwaysAttribute>() ?? false;
                         var hasAutoValidateNeverAttribute = parameterInfo?.HasCustomAttribute<AutoValidateNeverAttribute>() ?? false;
 
-                        if (subject != null && parameterType != null && parameterType.IsCustomType() && !hasAutoValidateNeverAttribute && (hasAutoValidateAlwaysAttribute || HasValidBindingSource(bindingSource)) && serviceProvider.GetValidator(parameterType) is IValidator validator)
+                        if (subject != null && parameterType != null && parameterType.IsCustomType() && !hasAutoValidateNeverAttribute && (hasAutoValidateAlwaysAttribute || HasValidBindingSource(bindingSource)) && serviceProvider.GetValidator(parameterType, false) is IValidator validator)
                         {
                             logger.LogDebug("Validating parameter '{Parameter}' of type '{Type}' for action '{Action}' on controller '{Controller}'.", parameter.Name, parameterType.Name, controllerActionDescriptor.ActionName, controllerActionDescriptor.ControllerName);
 

--- a/FluentValidation.AutoValidation.Shared/src/Extensions/ServiceProviderExtensions.cs
+++ b/FluentValidation.AutoValidation.Shared/src/Extensions/ServiceProviderExtensions.cs
@@ -1,13 +1,46 @@
 ﻿using System;
 using FluentValidation;
 
-namespace SharpGrip.FluentValidation.AutoValidation.Shared.Extensions
+namespace SharpGrip.FluentValidation.AutoValidation.Shared.Extensions;
+
+public static class ServiceProviderExtensions
 {
-    public static class ServiceProviderExtensions
+    public static object? GetValidator(this IServiceProvider serviceProvider, Type type, bool useBaseTypeValidations)
     {
-        public static object? GetValidator(this IServiceProvider serviceProvider, Type type)
+        var validator = serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(type));
+        if (validator is not null) return validator;
+        if (!useBaseTypeValidations) return null;
+
+        return GetValidatorFromBaseClasses(serviceProvider, type)
+               ?? GetValidatorFromInterfaces(serviceProvider, type);
+    }
+
+    private static object? GetValidatorFromBaseClasses(IServiceProvider serviceProvider, Type type)
+    {
+        var baseType = type.BaseType;
+        while (baseType is not null && baseType != typeof(object))
         {
-            return serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(type));
+            var baseValidatorType = typeof(IValidator<>).MakeGenericType(baseType);
+            var baseValidator = serviceProvider.GetService(baseValidatorType);
+
+            if (baseValidator is not null) return baseValidator;
+
+            baseType = baseType.BaseType;
         }
+
+        return null;
+    }
+
+    private static object? GetValidatorFromInterfaces(IServiceProvider serviceProvider, Type type)
+    {
+        foreach (var interfaceType in type.GetInterfaces())
+        {
+            var interfaceValidatorType = typeof(IValidator<>).MakeGenericType(interfaceType);
+            var interfaceValidator = serviceProvider.GetService(interfaceValidatorType);
+
+            if (interfaceValidator is not null) return interfaceValidator;
+        }
+
+        return null;
     }
 }

--- a/FluentValidation.AutoValidation.Shared/src/Extensions/TypeExtensions.cs
+++ b/FluentValidation.AutoValidation.Shared/src/Extensions/TypeExtensions.cs
@@ -7,26 +7,26 @@ namespace SharpGrip.FluentValidation.AutoValidation.Shared.Extensions
 {
     public static class TypeExtensions
     {
+        private static readonly HashSet<Type> builtInTypes =
+        [
+            typeof(string),
+            typeof(decimal),
+            typeof(DateTime),
+            typeof(DateTimeOffset),
+            typeof(TimeSpan),
+            typeof(DateOnly),
+            typeof(TimeOnly),
+            typeof(Uri),
+            typeof(Guid),
+            typeof(Enum)
+        ];
+        
         public static bool IsCustomType(this Type? type)
         {
             if (type == null || type.IsEnum || type.IsPrimitive)
             {
                 return false;
             }
-
-            var builtInTypes = new HashSet<Type>
-            {
-                typeof(string),
-                typeof(decimal),
-                typeof(DateTime),
-                typeof(DateTimeOffset),
-                typeof(TimeSpan),
-                typeof(DateOnly),
-                typeof(TimeOnly),
-                typeof(Uri),
-                typeof(Guid),
-                typeof(Enum)
-            };
 
             if (builtInTypes.Contains(type))
             {

--- a/Tests/src/FluentValidation.AutoValidation.Endpoints/Filters/FluentValidationAutoValidationEndpointFilterTest.cs
+++ b/Tests/src/FluentValidation.AutoValidation.Endpoints/Filters/FluentValidationAutoValidationEndpointFilterTest.cs
@@ -10,9 +10,12 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NSubstitute;
+using SharpGrip.FluentValidation.AutoValidation.Endpoints.Configuration;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Filters;
 using SharpGrip.FluentValidation.AutoValidation.Endpoints.Interceptors;
+using SharpGrip.FluentValidation.AutoValidation.Tests.Shared.Stubs;
 using Xunit;
 
 namespace SharpGrip.FluentValidation.AutoValidation.Tests.FluentValidation.AutoValidation.Endpoints.Filters;
@@ -32,6 +35,8 @@ public class FluentValidationAutoValidationEndpointFilterTest
         var logger = Substitute.For<ILogger<FluentValidationAutoValidationEndpointFilter>>();
         var serviceProvider = Substitute.For<IServiceProvider>();
         var endpointFilterInvocationContext = Substitute.For<EndpointFilterInvocationContext>();
+        var configuration = Substitute.For<IOptions<AutoValidationEndpointsConfiguration>>(); 
+        configuration.Value.Returns(new AutoValidationEndpointsConfiguration());
 
         endpointFilterInvocationContext.HttpContext.Returns(new DefaultHttpContext {RequestServices = serviceProvider});
         endpointFilterInvocationContext.Arguments.Returns(new List<object?> {new TestModel {Parameter1 = "Value 1", Parameter2 = "Value 2", Parameter3 = "Value 3"}});
@@ -40,7 +45,7 @@ public class FluentValidationAutoValidationEndpointFilterTest
 
         var validationFailuresValues = ValidationFailures.Values.ToList();
 
-        var endpointFilter = new FluentValidationAutoValidationEndpointFilter(logger);
+        var endpointFilter = new FluentValidationAutoValidationEndpointFilter(logger, configuration);
 
         var result = (ValidationProblem) (await endpointFilter.InvokeAsync(endpointFilterInvocationContext, _ => ValueTask.FromResult(new object())!))!;
         var problemDetailsErrorValues = result.ProblemDetails.Errors.ToList();
@@ -56,18 +61,68 @@ public class FluentValidationAutoValidationEndpointFilterTest
         var logger = Substitute.For<ILogger<FluentValidationAutoValidationEndpointFilter>>();
         var serviceProvider = Substitute.For<IServiceProvider>();
         var endpointFilterInvocationContext = Substitute.For<EndpointFilterInvocationContext>();
+        var configuration = Substitute.For<IOptions<AutoValidationEndpointsConfiguration>>(); 
+        configuration.Value.Returns(new AutoValidationEndpointsConfiguration());
 
         endpointFilterInvocationContext.HttpContext.Returns(new DefaultHttpContext {RequestServices = serviceProvider});
         endpointFilterInvocationContext.Arguments.Returns(new List<object?> {new TestModel {Parameter1 = "Value 1", Parameter2 = "Value 2", Parameter3 = "Value 3"}});
         serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(typeof(TestModel))).Returns(null);
         serviceProvider.GetService(typeof(IGlobalValidationInterceptor)).Returns(null);
 
-        var endpointFilter = new FluentValidationAutoValidationEndpointFilter(logger);
+        var endpointFilter = new FluentValidationAutoValidationEndpointFilter(logger, configuration);
 
         var result = await endpointFilter.InvokeAsync(endpointFilterInvocationContext, _ => ValueTask.FromResult(new object())!);
 
         Assert.IsType<object>(result);
     }
+    
+    [Fact]
+    public async Task TestInvokeAsync_BaseTypeValidatorNotFound()
+    {
+        var logger = Substitute.For<ILogger<FluentValidationAutoValidationEndpointFilter>>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var endpointFilterInvocationContext = Substitute.For<EndpointFilterInvocationContext>();
+        var configuration = Substitute.For<IOptions<AutoValidationEndpointsConfiguration>>(); 
+        configuration.Value.Returns(new AutoValidationEndpointsConfiguration());
+
+        endpointFilterInvocationContext.HttpContext.Returns(new DefaultHttpContext {RequestServices = serviceProvider});
+        endpointFilterInvocationContext.Arguments.Returns(new List<object?> {new CreatePostRequest()});
+        serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(typeof(CreatePostRequest))).Returns(null);
+        serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(typeof(ICreatePost))).Returns(new CreatePostValidator());
+        serviceProvider.GetService(typeof(IGlobalValidationInterceptor)).Returns(null);
+
+        var endpointFilter = new FluentValidationAutoValidationEndpointFilter(logger, configuration);
+
+        var result = await endpointFilter.InvokeAsync(endpointFilterInvocationContext, _ => ValueTask.FromResult(new object())!);
+
+        Assert.IsType<object>(result);
+    } 
+    
+    [Fact]
+    public async Task TestInvokeAsync_BaseTypeValidatorFound()
+    {
+        var logger = Substitute.For<ILogger<FluentValidationAutoValidationEndpointFilter>>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        var endpointFilterInvocationContext = Substitute.For<EndpointFilterInvocationContext>();
+        var configuration = Substitute.For<IOptions<AutoValidationEndpointsConfiguration>>(); 
+        configuration.Value.Returns(new AutoValidationEndpointsConfiguration().WithBaseTypeValidations());
+
+        endpointFilterInvocationContext.HttpContext.Returns(new DefaultHttpContext {RequestServices = serviceProvider});
+        endpointFilterInvocationContext.Arguments.Returns(new List<object?> {new CreatePostRequest()});
+        serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(typeof(CreatePostRequest))).Returns(null);
+        serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(typeof(ICreatePost))).Returns(new CreatePostValidator());
+        serviceProvider.GetService(typeof(IGlobalValidationInterceptor)).Returns(new GlobalValidationInterceptor());
+
+        var endpointFilter = new FluentValidationAutoValidationEndpointFilter(logger, configuration);
+
+        var result = await endpointFilter.InvokeAsync(endpointFilterInvocationContext, _ => ValueTask.FromResult<object?>(new object()));
+        Assert.IsType<ValidationProblem>(result, false);
+        var problem = result as ValidationProblem;
+        var problemDetailsErrorValues = problem.ProblemDetails.Errors.ToList();
+        
+        Assert.Contains(problemDetailsErrorValues, x => x.Value.Contains("Title cannot be null or empty."));
+        Assert.Contains(problemDetailsErrorValues, x => x.Value.Contains("Body cannot be null or empty."));
+    }     
 
     private class TestModel
     {

--- a/Tests/src/FluentValidation.AutoValidation.Shared/Extensions/ServiceProviderExtensionsTest.cs
+++ b/Tests/src/FluentValidation.AutoValidation.Shared/Extensions/ServiceProviderExtensionsTest.cs
@@ -4,6 +4,7 @@ using System;
 using FluentValidation;
 using NSubstitute;
 using SharpGrip.FluentValidation.AutoValidation.Shared.Extensions;
+using SharpGrip.FluentValidation.AutoValidation.Tests.Shared.Stubs;
 using Xunit;
 
 namespace SharpGrip.FluentValidation.AutoValidation.Tests.FluentValidation.AutoValidation.Shared.Extensions;
@@ -20,8 +21,26 @@ public class ServiceProviderExtensionsTest
 
         serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(testModel.GetType())).Returns(testModelValidator);
 
-        var validator = serviceProvider.GetValidator(testModel.GetType());
+        var validator = serviceProvider.GetValidator(testModel.GetType(), false);
 
+        Assert.Equal(testModelValidator, validator);
+    }
+
+    [Fact]
+    public void Test_GetValidator_WithBaseTypeValidator()
+    {
+        var serviceProvider = Substitute.For<IServiceProvider>();
+
+        var testModel = new CreatePostRequest();
+        var testModelValidator = new CreatePostValidator();
+
+        serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(testModel.GetType())).Returns(null);
+        serviceProvider.GetService(typeof(IValidator<>).MakeGenericType(typeof(ICreatePost))).Returns(testModelValidator);
+
+        var validator = serviceProvider.GetValidator(testModel.GetType(), false);
+        Assert.Null(validator);
+
+        validator = serviceProvider.GetValidator(testModel.GetType(), true);
         Assert.Equal(testModelValidator, validator);
     }
 

--- a/Tests/src/Shared/GlobalSetup.cs
+++ b/Tests/src/Shared/GlobalSetup.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+using System.Threading;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: Xunit.TestFramework("SharpGrip.FluentValidation.AutoValidation.Tests.Shared.GlobalSetup", "FluentValidation.AutoValidation.Tests")]
+namespace SharpGrip.FluentValidation.AutoValidation.Tests.Shared;
+
+public class GlobalSetup : XunitTestFramework
+{
+    public GlobalSetup(IMessageSink messageSink) : base(messageSink)
+    {
+        SetupEnvironment();
+    }
+
+    private static void SetupEnvironment()
+    {
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
+    }
+}

--- a/Tests/src/Shared/Stubs/CreatePostRequest.cs
+++ b/Tests/src/Shared/Stubs/CreatePostRequest.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+
+namespace SharpGrip.FluentValidation.AutoValidation.Tests.Shared.Stubs;
+
+public interface ICreatePost
+{
+    string Body { get; }
+    string Title { get; }
+}
+
+public class CreatePostRequest : ICreatePost
+{
+    public string Body { get; set; } = null!;
+    public string Title { get; set; } = null!;
+}
+
+public class CreatePostValidator : AbstractValidator<ICreatePost>
+{
+    public CreatePostValidator()
+    {
+        RuleFor(req => req.Title).NotEmpty().WithMessage("Title cannot be null or empty.");
+        RuleFor(req => req.Body).NotEmpty().WithMessage("Body cannot be null or empty.");
+    }
+}

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear/>
+    <add key="Oficial - Nuget" value="https://api.nuget.org/v3/index.json"/>
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Hello to all contributors and maintainers. I would like to thank you for the great work being done on this project.

### Motivation and Context

The current automatic validation pipeline rigidly resolves validators by looking for the exact type of the endpoint parameter. This prevents the validation of DTOs implementing interfaces or inheriting from base classes when the validator is defined for the abstraction.

This PR introduces the `WithBaseTypeValidations` setting, enabling the lookup engine to traverse the type hierarchy if a specific validator for the concrete type is not found. This enhancement will be essential for utilizing this library in an important, large-scale project I am currently working on.

### Changes Made

* **Configuration**: Added the `UseBaseTypeValidations` flag and the `WithBaseTypeValidations()` fluent method.
* **Lookup Refactoring**: The `GetValidator` method now performs a recursive search ordered by: Concrete Type, Base Classes, and Interfaces.
* **Scope**: This change focuses on Minimal APIs. I deliberately chose not to modify MVC behavior at this stage. If required, support can be added in a separate PR by introducing a specific configuration and injecting it into the MVC `ActionFilter`.
* **Documentation**: Added XML comments to explain the new polymorphic behavior.

### Benefits

* **Reuse**: Allows global rules on interfaces or base classes without duplicating validation logic.
* **Flexibility**: Native support for architectures using polymorphism in commands and DTOs.
* **Reliability**: Ensures standardized contracts are validated according to project standards.